### PR TITLE
Black white listing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,16 @@ squid_cache_peer: []
  #   icp_port: '{{ squid_icp_port }}'
  #   options: default
 
+# This sets up domain whielist and blacklist support files.
+squid_domain_lists_dir: "{ squid_root_dir }}/domain_lists"
+squid_domain_blacklist_file: domain_blacklist
+squid_domain_whitelist_file: domain_whitelist
+
+# This will be setup via invoking playbook
+squid_domain_whitelist: []
+squid_domain_blacklist: []
+
+
 squid_cache_peering: false
 
 squid_http_access:
@@ -71,6 +81,10 @@ squid_http_access:
     acl:
       - 'CONNECT'
       - '!SSL_ports'
+  - action: 'deny'
+    acl:
+      - all
+      - domain_blacklist
   - action: 'allow'
     acl:
       - 'localhost'
@@ -84,6 +98,10 @@ squid_http_access:
   - action: 'allow'
     acl:
       - 'localnet'
+  - action: 'allow'
+    acl:
+      - all
+      - domain_whitelist
   - action: 'deny'
     acl:
       - 'all'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,10 @@ squid_http_access:
     acl:
       - 'CONNECT'
       - '!SSL_ports'
+  - action: 'allow'
+    acl:
+      - all
+      - domain_whitelist
   - action: 'deny'
     acl:
       - all
@@ -98,10 +102,6 @@ squid_http_access:
   - action: 'allow'
     acl:
       - 'localnet'
-  - action: 'allow'
-    acl:
-      - all
-      - domain_whitelist
   - action: 'deny'
     acl:
       - 'all'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ squid_cache_peer: []
  #   options: default
 
 # This sets up domain whielist and blacklist support files.
-squid_domain_lists_dir: "{ squid_root_dir }}/domain_lists"
+squid_domain_lists_dir: "{{ squid_root_dir }}/domain_lists"
 squid_domain_blacklist_file: domain_blacklist
 squid_domain_whitelist_file: domain_whitelist
 

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -16,6 +16,6 @@
     mode: 0644
   become: true
   with_items:
-    - squid_domain_blacklist_file
-    - squid_domain_whitelist_file
+    - "{{ squid_domain_blacklist_file }}"
+    - "{{ squid_domain_whitelist_file }} "
   notify: "restart {{ squid_service }}"

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -17,5 +17,5 @@
   become: true
   with_items:
     - "{{ squid_domain_blacklist_file }}"
-    - "{{ squid_domain_whitelist_file }} "
+    - "{{ squid_domain_whitelist_file }}"
   notify: "restart {{ squid_service }}"

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -1,0 +1,21 @@
+---
+- name: config_squid_domain_lists | Ensure Squid domain lists directory
+  file:
+    path: "{{ squid_domain_lists_dir }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: 0755
+
+- name: config_squid_domain_lists | Configure domain lists
+  template:
+    src: "domain_lists/{{ item }}.j2"
+    dest: "{{ squid_domain_lists_dir }}{{ item }}"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  become: true
+  with_items:
+    - squid_domain_blacklist_file
+    - squid_domain_whitelist_file
+  notify: "restart {{ squid_service }}"

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -9,7 +9,7 @@
 
 - name: config_squid_domain_lists | Configure domain lists
   template:
-    src: "domain_lists/{{ item }}.j2"
+    src: "squid/domain_lists/{{ item }}.j2"
     dest: "{{ squid_domain_lists_dir }}{{ item }}"
     owner: "root"
     group: "root"

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -9,7 +9,7 @@
 
 - name: config_squid_domain_lists | Configure domain lists
   template:
-    src: "squid/domain_lists/{{ item }}.j2"
+    src: "etc/squid/domain_lists/{{ item }}.j2"
     dest: "{{ squid_domain_lists_dir }}{{ item }}"
     owner: "root"
     group: "root"

--- a/tasks/config_squid_domain_lists.yml
+++ b/tasks/config_squid_domain_lists.yml
@@ -10,7 +10,7 @@
 - name: config_squid_domain_lists | Configure domain lists
   template:
     src: "etc/squid/domain_lists/{{ item }}.j2"
-    dest: "{{ squid_domain_lists_dir }}{{ item }}"
+    dest: "{{ squid_domain_lists_dir }}/{{ item }}"
     owner: "root"
     group: "root"
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,4 +28,7 @@
 
 - name: Setup domain lists (black and white)
   include: config_squid_domain_lists.yml
-  when: squid_domain_lists_dir != ""
+  when: >
+    squid_domain_lists_dir != "" and
+    (squid_domain_blacklist_file is defined or
+    squid_domain_whitelist_file is defined)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,7 @@
   template:
     src: etc/squid/conf.d/dummy.conf.j2
     dest: "{{ squid_root_dir }}/conf.d/dummy.conf"
+
+- Name: Setup domain lists (black and white)
+  include: config_squid_domain_lists
+  when: squid_domain_lists_dir != ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,5 +30,5 @@
   include: config_squid_domain_lists.yml
   when: >
     squid_domain_lists_dir != "" and
-    (squid_domain_blacklist_file is defined or
-    squid_domain_whitelist_file is defined)
+    (squid_domain_blacklist_file | length > 0 ) or
+    squid_domain_whitelist_file | length > 0 )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,6 @@
     src: etc/squid/conf.d/dummy.conf.j2
     dest: "{{ squid_root_dir }}/conf.d/dummy.conf"
 
-- Name: Setup domain lists (black and white)
-  include: config_squid_domain_lists
+- name: Setup domain lists (black and white)
+  include: config_squid_domain_lists.yml
   when: squid_domain_lists_dir != ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,4 +31,4 @@
   when: >
     squid_domain_lists_dir != "" and
     (squid_domain_blacklist_file | length > 0 ) or
-    squid_domain_whitelist_file | length > 0 )
+    (squid_domain_whitelist_file | length > 0 )

--- a/templates/etc/squid/domain_lists/domain_blacklist.j2
+++ b/templates/etc/squid/domain_lists/domain_blacklist.j2
@@ -1,0 +1,3 @@
+{% for domain in squid_domain_blacklist %}
+domain
+{% endfor %}

--- a/templates/etc/squid/domain_lists/domain_blacklist.j2
+++ b/templates/etc/squid/domain_lists/domain_blacklist.j2
@@ -1,3 +1,5 @@
+{% if squid_domain_blacklist is defined and squid_domain_blacklist is iterable %}
 {% for domain in squid_domain_blacklist %}
 {{ domain }}
 {% endfor %}
+{% endif %}

--- a/templates/etc/squid/domain_lists/domain_blacklist.j2
+++ b/templates/etc/squid/domain_lists/domain_blacklist.j2
@@ -1,3 +1,3 @@
 {% for domain in squid_domain_blacklist %}
-domain
+{{ domain }}
 {% endfor %}

--- a/templates/etc/squid/domain_lists/domain_whitelist.j2
+++ b/templates/etc/squid/domain_lists/domain_whitelist.j2
@@ -1,4 +1,4 @@
-{% if squid_domain_whitelist is defined%}
+{% if squid_domain_whitelist is defined and squid_domain_whitelist is iterable%}
 {% for domain in squid_domain_whitelist %}
 {{ domain }}
 {% endfor %}

--- a/templates/etc/squid/domain_lists/domain_whitelist.j2
+++ b/templates/etc/squid/domain_lists/domain_whitelist.j2
@@ -1,3 +1,5 @@
+{% if squid_domain_whitelist is defined%}
 {% for domain in squid_domain_whitelist %}
 {{ domain }}
 {% endfor %}
+{% endif %}

--- a/templates/etc/squid/domain_lists/domain_whitelist.j2
+++ b/templates/etc/squid/domain_lists/domain_whitelist.j2
@@ -1,3 +1,3 @@
 {% for domain in squid_domain_whitelist %}
-domain
+{{ domain }}
 {% endfor %}

--- a/templates/etc/squid/domain_lists/domain_whitelist.j2
+++ b/templates/etc/squid/domain_lists/domain_whitelist.j2
@@ -1,0 +1,3 @@
+{% for domain in squid_domain_whitelist %}
+domain
+{% endfor %}

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 
 # Domain blacklisting/whitelisting
-{% if squid_domain_blacklist_file is defined and squid_acl != "" %}
+{% if squid_domain_blacklist_file is defined and squid_domain_blacklist != [] %}
 acl domain_blacklist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_blacklist_file }}"
 {% endif %}
-{% if squid_domain_whitelist_file is defined and squid_acl != "" %}
+{% if squid_domain_whitelist_file is defined and squid_domain_whitelist != "" %}
 acl domain_whitelist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_whitelist_file }}"
 {% endif %}
 

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -43,7 +43,7 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 {% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file is not defined or squid_domain_whitelist != []) %}
 {% else %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}
-{%% endif %}
+{% endif %}
 {%   endfor %}
 {% endif %}
 

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -1,5 +1,15 @@
 # {{ ansible_managed }}
 
+# Domain blacklisting/whitelisting
+
+{% if squid_domain_blacklist_file is defined and squid_acl != "" %}
+acl domain_blacklist dstdomain "{{ squid_domain_blacklist_file }}"
+{% endif %}
+
+{% if squid_domain_whitelist_file is defined and squid_acl != "" %}
+acl domain_whitelist dstdomain "{{ squid_domain_whitelist_file }}"
+{% endif %}
+
 # ACLS
 {% if squid_acl is defined and squid_acl != [] %}
 {%   for item in squid_acl %}

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -1,13 +1,11 @@
 # {{ ansible_managed }}
 
 # Domain blacklisting/whitelisting
-
 {% if squid_domain_blacklist_file is defined and squid_acl != "" %}
-acl domain_blacklist dstdomain "{{ squid_domain_blacklist_file }}"
+acl domain_blacklist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_blacklist_file }}"
 {% endif %}
-
 {% if squid_domain_whitelist_file is defined and squid_acl != "" %}
-acl domain_whitelist dstdomain "{{ squid_domain_whitelist_file }}"
+acl domain_whitelist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_whitelist_file }}"
 {% endif %}
 
 # ACLS

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -39,8 +39,8 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 
 {% if squid_http_access is defined and squid_http_access != [] %}
 {%   for item in squid_http_access %}
-{% if 'domain_blacklist' in item['acl'] and (squid_domain_blacklist_file is not defined or squid_domain_blacklist == []) %}
-{% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file is not defined or squid_domain_whitelist == []) %}
+{% if 'domain_blacklist' in item['acl'] and (squid_domain_blacklist_file | length == 0  or squid_domain_blacklist == []) %}
+{% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file | length == 0 or squid_domain_whitelist == []) %}
 {% else %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}
 {% endif %}

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -39,7 +39,11 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 
 {% if squid_http_access is defined and squid_http_access != [] %}
 {%   for item in squid_http_access %}
+{% if 'domain_blacklist' in item['acl'] and (squid_domain_blacklist_file is not defined or squid_domain_blacklist != []) %}
+{% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file is not defined or squid_domain_whitelist != []) %}
+{% else %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}
+{%% endif %}
 {%   endfor %}
 {% endif %}
 

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -39,8 +39,8 @@ acl Safe_ports port {{ item['port'] }}{% if item['comment'] is defined %} #{{ it
 
 {% if squid_http_access is defined and squid_http_access != [] %}
 {%   for item in squid_http_access %}
-{% if 'domain_blacklist' in item['acl'] and (squid_domain_blacklist_file is not defined or squid_domain_blacklist != []) %}
-{% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file is not defined or squid_domain_whitelist != []) %}
+{% if 'domain_blacklist' in item['acl'] and (squid_domain_blacklist_file is not defined or squid_domain_blacklist == []) %}
+{% elif 'domain_whitelist' in item['acl'] and (squid_domain_whitelist_file is not defined or squid_domain_whitelist == []) %}
 {% else %}
 http_access {{ item['action'] }} {{ item['acl']|join(' ') }}
 {% endif %}

--- a/templates/etc/squid/squid.conf.j2
+++ b/templates/etc/squid/squid.conf.j2
@@ -4,7 +4,7 @@
 {% if squid_domain_blacklist_file is defined and squid_domain_blacklist != [] %}
 acl domain_blacklist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_blacklist_file }}"
 {% endif %}
-{% if squid_domain_whitelist_file is defined and squid_domain_whitelist != "" %}
+{% if squid_domain_whitelist_file is defined and squid_domain_whitelist != [] %}
 acl domain_whitelist dstdomain "{{ squid_domain_lists_dir }}/{{ squid_domain_whitelist_file }}"
 {% endif %}
 


### PR DESCRIPTION
Allows to define HTTP dst_domain blacklists and whitelists by introducing two list vars:

- `squid_domain_whitelist: []`
- `squid_domain_blacklist: []` 

These will be templated to two files:
- `squid_domain_blacklist_file`
- `squid_domain_whitelist_file`

and conditionally included and configured in main squid.conf.